### PR TITLE
Update background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -538,8 +538,8 @@ var History = {
 					return funcCallback({});
 
 				} else if (objArguments.objGet.strTitle.trim() === '') {
-					return funcCallback({});
-
+					// Firefox and Chrome history show full URL when page title is missing
+					objArguments.objGet.strTitle = 'https://www.youtube.com/watch?v=' + objArguments.objGet.strIdent.trim();
 				}
 
 				var objQuery = objArguments.objDatabase.put(objArguments.objGet);


### PR DESCRIPTION
Use full URL for title if the video title is missing.
This is consistent with the way Firefox and Chrome history show pages with no title.
The existing code already udpates the title if a later viewing successfully fetches a title.