### PR TITLE
Youtube requests missing headers

### DIFF
--- a/background.js
+++ b/background.js
@@ -1327,6 +1327,8 @@ var Search = {
                     // objAjax.setRequestHeader('Referer', 'https://www.youtube.com/feed/history'); // not allowed on chrome
                     // objAjax.setRequestHeader('Origin', 'https://www.youtube.com'); // not allowed on chrome
                     objAjax.setRequestHeader('X-Origin', 'https://www.youtube.com');
+                    objAjax.setRequestHeader('X-Goog-AuthUser', '0');
+                    objAjax.setRequestHeader('X-Goog-PageId', objArguments.objYtcfg['DELEGATED_SESSION_ID']);
                     objAjax.setRequestHeader('X-Goog-Visitor-Id', objArguments.objYtctx['client']['visitorData']);
 
                     objArguments.objYtctx['client']['screenWidthPoints'] = 1024;

--- a/background.js
+++ b/background.js
@@ -763,6 +763,8 @@ var Youtube = {
                     // objAjax.setRequestHeader('Referer', 'https://www.youtube.com/feed/history'); // not allowed on chrome
                     // objAjax.setRequestHeader('Origin', 'https://www.youtube.com'); // not allowed on chrome
                     objAjax.setRequestHeader('X-Origin', 'https://www.youtube.com');
+                    objAjax.setRequestHeader('X-Goog-AuthUser', '0');
+                    objAjax.setRequestHeader('X-Goog-PageId', objArguments.objYtcfg['DELEGATED_SESSION_ID']);
                     objAjax.setRequestHeader('X-Goog-Visitor-Id', objArguments.objYtctx['client']['visitorData']);
 
                     objArguments.objYtctx['client']['screenWidthPoints'] = 1024;
@@ -1389,6 +1391,8 @@ var Search = {
                 // objAjax.setRequestHeader('Referer', 'https://www.youtube.com/feed/history'); // not allowed on chrome
                 // objAjax.setRequestHeader('Origin', 'https://www.youtube.com'); // not allowed on chrome
                 objAjax.setRequestHeader('X-Origin', 'https://www.youtube.com');
+                objAjax.setRequestHeader('X-Goog-AuthUser', '0');
+                objAjax.setRequestHeader('X-Goog-PageId', objArguments.objYtcfg['DELEGATED_SESSION_ID']);
                 objAjax.setRequestHeader('X-Goog-Visitor-Id', objArguments.objYtctx['client']['visitorData']);
 
                 objArguments.objYtctx['client']['screenWidthPoints'] = 1024;


### PR DESCRIPTION
Despite receiving a 200 status response from the youtube delete request, the video remained in the history.
After debugging with Postman I noticed that 2 headers required for the deletion were not present.