### PR TITLE
Various fixes

### DIFF
--- a/background.js
+++ b/background.js
@@ -182,9 +182,8 @@ var Database = {
                                         'objResponse': objResponse
                                     });
                                 });
-                            }
 
-                            if (objData.strMessage === 'databaseImport') {
+                            } else if (objData.strMessage === 'databaseImport') {
                                 Database.import(objData.objRequest, function(objResponse) {
                                     objPort.postMessage({
                                         'strMessage': 'databaseImport',
@@ -196,15 +195,15 @@ var Database = {
                                         'objResponse': objResponse
                                     });
                                 });
-                            }
 
-                            if (objData.strMessage === 'databaseReset') {
+                            } else if (objData.strMessage === 'databaseReset') {
                                 Database.reset(objData.objRequest, function(objResponse) {
                                     objPort.postMessage({
                                         'strMessage': 'databaseReset',
                                         'objResponse': objResponse
                                     });
                                 });
+
                             }
                         });
                     }
@@ -604,33 +603,31 @@ var Youtube = {
                                         'objResponse': objResponse
                                     });
                                 });
-                            }
 
-                            if (objData.strMessage === 'youtubeLookup') {
+                            } else if (objData.strMessage === 'youtubeLookup') {
                                 Youtube.lookup(objData.objRequest, function(objResponse) {
                                     objPort.postMessage({
                                         'strMessage': 'youtubeLookup',
                                         'objResponse': objResponse
                                     });
                                 });
-                            }
 
-                            if (objData.strMessage === 'youtubeEnsure') {
+                            } else if (objData.strMessage === 'youtubeEnsure') {
                                 Youtube.ensure(objData.objRequest, function(objResponse) {
                                     objPort.postMessage({
                                         'strMessage': 'youtubeEnsure',
                                         'objResponse': objResponse
                                     });
                                 });
-                            }
 
-                            if (objData.strMessage === 'youtubeMark') {
+                            } else if (objData.strMessage === 'youtubeMark') {
                                 Youtube.mark(objData.objRequest, function(objResponse) {
                                     objPort.postMessage({
                                         'strMessage': 'youtubeMark',
                                         'objResponse': objResponse
                                     });
                                 });
+
                             }
                         });
                     }
@@ -1079,9 +1076,8 @@ var Search = {
                                         'objResponse': objResponse
                                     });
                                 });
-                            }
 
-                            if (objData.strMessage === 'searchDelete') {
+                            } else if (objData.strMessage === 'searchDelete') {
                                 Search.delete(objData.objRequest, function(objResponse) {
                                     objPort.postMessage({
                                         'strMessage': 'searchDelete',
@@ -1093,6 +1089,7 @@ var Search = {
                                         'objResponse': objResponse
                                     });
                                 });
+
                             }
                         });
                     }

--- a/background.js
+++ b/background.js
@@ -710,24 +710,24 @@ var Youtube = {
                     }
 
                     var strRegex = null;
-                    var objContinuation = new RegExp('("continuationCommand":)([^"]*)("token":)([^"]*)(")([^"]*)(")', 'g');
-                    var objClicktrack = new RegExp('("continuationEndpoint":)([^"]*)("clickTrackingParams":)([^"]*)(")([^"]*)(")', 'g');
-                    var objVideo = new RegExp('("videoRenderer":)([^"]*)("videoId":)([^"]*)(")([^"]{11})(")(.*?)("text")([^"]*)(")([^"]*)(")', 'g');
+                    var reContinuation = /"continuationCommand":[^"]*"token":[^"]*"([^"]*)"/g;
+                    var reClicktrack = /"continuationEndpoint":[^"]*"clickTrackingParams":[^"]*"([^"]*)"/g;
+                    var reVideo = /"videoRenderer":[^"]*"videoId":[^"]*"([^"]{11})".*?"text"[^"]*"([^"]*)"/g;
                     var strUnescaped = objAjax.responseText.split('\\"').join('\\u0022').split('\r').join('').split('\n').join('');
 
-                    if ((strRegex = objContinuation.exec(strUnescaped)) !== null) {
-                        objArguments.strContinuation = strRegex[6];
+                    if ((strRegex = reContinuation.exec(strUnescaped)) !== null) {
+                        objArguments.strContinuation = strRegex[1];
                     }
 
-                    if ((strRegex = objClicktrack.exec(strUnescaped)) !== null) {
-                        objArguments.strClicktrack = strRegex[6];
+                    if ((strRegex = reClicktrack.exec(strUnescaped)) !== null) {
+                        objArguments.strClicktrack = strRegex[1];
                     }
 
                     var objVideos = [];
 
-                    while ((strRegex = objVideo.exec(strUnescaped)) !== null) {
-                        var strIdent = strRegex[6];
-                        var strTitle = strRegex[12];
+                    while ((strRegex = reVideo.exec(strUnescaped)) !== null) {
+                        var strIdent = strRegex[1];
+                        var strTitle = strRegex[2];
 
                         strTitle = strTitle.split('\\u0022').join('"');
                         strTitle = strTitle.split('\\u0026').join('&');
@@ -1281,23 +1281,23 @@ var Search = {
                     }
 
                     var strRegex = null;
-                    var objContinuation = new RegExp('("continuationCommand":)([^"]*)("token":)([^"]*)(")([^"]*)(")', 'g');
-                    var objClicktrack = new RegExp('("continuationEndpoint":)([^"]*)("clickTrackingParams":)([^"]*)(")([^"]*)(")', 'g');
-                    var objVideo = new RegExp('("videoRenderer":)([^"]*)("videoId":)([^"]*)(")([^"]{11})(")(.*?)("topLevelButtons")(.*?)("clickTrackingParams")([^"]*)(")([^"]*)(")(.*?)("feedbackToken")([^"]*)(")([^"]*)(")', 'g');
+                    var reContinuation = /"continuationCommand":[^"]*"token":[^"]*"([^"]*)"/g;
+                    var reClicktrack = /"continuationEndpoint":[^"]*"clickTrackingParams":[^"]*"([^"]*)"/g;
+                    var reVideo = /"videoRenderer":[^"]*"videoId":[^"]*"([^"]{11})".*?"topLevelButtons".*?"clickTrackingParams"[^"]*"([^"]*)".*?"feedbackToken"[^"]*"([^"]*)"/g;
                     var strUnescaped = objAjax.responseText.split('\\"').join('\\u0022').split('\r').join('').split('\n').join('');
 
-                    if ((strRegex = objContinuation.exec(strUnescaped)) !== null) {
-                        objArguments.strContinuation = strRegex[6];
+                    if ((strRegex = reContinuation.exec(strUnescaped)) !== null) {
+                        objArguments.strContinuation = strRegex[1];
                     }
 
-                    if ((strRegex = objClicktrack.exec(strUnescaped)) !== null) {
-                        objArguments.strClicktrack = strRegex[6];
+                    if ((strRegex = reClicktrack.exec(strUnescaped)) !== null) {
+                        objArguments.strClicktrack = strRegex[1];
                     }
 
-                    while ((strRegex = objVideo.exec(strUnescaped)) !== null) {
-                        var strIdent = strRegex[6];
-                        var strClicktrack = strRegex[14];
-                        var strFeedback = strRegex[20];
+                    while ((strRegex = reVideo.exec(strUnescaped)) !== null) {
+                        var strIdent = strRegex[1];
+                        var strClicktrack = strRegex[2];
+                        var strFeedback = strRegex[3];
 
                         if (strIdent !== objRequest.strIdent) {
                             continue;
@@ -1629,7 +1629,7 @@ Node.series({
 
             }
 
-            var strIdent = new RegExp('(\\/vi\\/)([^ ]*)(\\/)', 'g').exec(objData.url)[2];
+            var strIdent = /\/vi\/([^ ]*)\//g.exec(objData.url)[1];
             var strTitle = undefined;
 
             Youtube.lookup({

--- a/background.js
+++ b/background.js
@@ -930,7 +930,7 @@ var Youtube = {
                 funcResponse(null);
 
             } else if (objArguments !== null) {
-                funcResponse({});
+                funcResponse(objArguments.objGet);
 
             }
         });
@@ -1539,7 +1539,9 @@ Node.series({
                         'strTitle': objRequest.strTitle
                     }, function(objResponse) {
                         console.log('ensured video', objRequest);
+                        funcResponse(null);
                     });
+                    return true; // indicate asynchronous response
                 }
 
             } else if (objRequest.strMessage === 'youtubeLookup') {
@@ -1547,16 +1549,10 @@ Node.series({
                     Youtube.lookup({
                         'strIdent': objRequest.strIdent
                     }, function(objResponse) {
-                        if (objResponse !== null) {
-                            console.debug('lookup video', objRequest.strIdent, 'already watched');
-                            funcSendmessage(objSender.tab.id, {
-                                'strMessage': 'youtubeMark',
-                                'strIdent': objRequest.strIdent
-                            });
-                        } else {
-                            console.debug('lookup video', objRequest.strIdent, 'not yet watched');
-                        }
+                        console.debug('lookup video', objRequest.strIdent, '=>', objResponse);
+                        funcResponse(objResponse);
                     });
+                    return true; // indicate asynchronous response
                 }
 
             }

--- a/background.js
+++ b/background.js
@@ -1538,10 +1538,11 @@ Node.series({
                         'strIdent': objRequest.strIdent,
                         'strTitle': objRequest.strTitle
                     }, function(objResponse) {
-                        console.log('ensured video');
+                        console.log('ensured video', objRequest);
                     });
                 }
             }
+            funcResponse(null);
         });
 
         return funcCallback({});

--- a/youtube.js
+++ b/youtube.js
@@ -24,11 +24,16 @@ var refresh = function() {
         if (boolMarkcache[strIdent] === false) {
             boolMarkcache[strIdent] = true;
 
-            chrome.runtime.sendMessage({
-                'strMessage': 'youtubeEnsure',
-                'strIdent': strIdent,
-                'strTitle': document.querySelector('a[title][href^="/watch?v=' + strIdent + '"], a[title][href^="/shorts/' + strIdent + '"]').title
-            });
+            var objTitle = document.querySelector('a[title][href^="/watch?v=' + strIdent + '"], a[title][href^="/shorts/' + strIdent + '"], a[href^="/watch?v=' + strIdent + '"] #video-title[title]');
+            if (objTitle === null) {
+                console.error('could not find title for video', strIdent)
+            } else {
+                chrome.runtime.sendMessage({
+                    'strMessage': 'youtubeEnsure',
+                    'strIdent': strIdent,
+                    'strTitle': objTitle.title
+                });
+            }
         }
     }
 

--- a/youtube.js
+++ b/youtube.js
@@ -60,7 +60,7 @@ var mark = function(objVideo, boolMark) {
 
 // ##########################################################
 
-chrome.runtime.onMessage.addListener(function(objData) {
+chrome.runtime.onMessage.addListener(function(objData, sender, sendResponse) {
     if (objData.strMessage === 'youtubeRefresh') {
         refresh();
     }
@@ -71,7 +71,10 @@ chrome.runtime.onMessage.addListener(function(objData) {
         for (var objVideo of document.querySelectorAll('a.ytd-thumbnail[href^="/watch?v=' + objData.strIdent + '"], a.ytd-thumbnail[href^="/shorts/' + objData.strIdent + '"]')) {
             mark(objVideo, true);
         }
-    } 
+    }
+
+    // synchronous response to prevent "The message port closed before a response was received."
+    sendResponse(null);
 });
 
 // ##########################################################

--- a/youtube.js
+++ b/youtube.js
@@ -41,7 +41,14 @@ var refresh = function() {
         var strIdent = objVideo.href.split('&')[0].slice(-11);
 
         if (boolMarkcache.hasOwnProperty(strIdent) === false) {
+            // Initialize to false for now, but fire youtubeLookup message to background,
+            // which will reply with youtubeMark message if it's actually already watched.
             boolMarkcache[strIdent] = false;
+
+            chrome.runtime.sendMessage({
+                'strMessage': 'youtubeLookup',
+                'strIdent': strIdent
+            });
         }
 
         mark(objVideo, boolMarkcache[strIdent]);
@@ -66,6 +73,8 @@ chrome.runtime.onMessage.addListener(function(objData, sender, sendResponse) {
     }
 
     if (objData.strMessage === 'youtubeMark') {
+        console.debug('youtubeMark:', objData.strIdent);
+
         boolMarkcache[objData.strIdent] = true;
 
         for (var objVideo of document.querySelectorAll('a.ytd-thumbnail[href^="/watch?v=' + objData.strIdent + '"], a.ytd-thumbnail[href^="/shorts/' + objData.strIdent + '"]')) {

--- a/youtube.js
+++ b/youtube.js
@@ -48,14 +48,28 @@ var refresh = function() {
             chrome.runtime.sendMessage({
                 'strMessage': 'youtubeLookup',
                 'strIdent': strIdent
+            }, function(objResponse) {
+                if (objResponse) {
+                    mark(objResponse.strIdent, true);
+                }
             });
         }
 
-        mark(objVideo, boolMarkcache[strIdent]);
+        markStyle(objVideo, boolMarkcache[strIdent]);
     }
 };
 
-var mark = function(objVideo, boolMark) {
+var mark = function(strIdent, boolMark) {
+    console.debug('markForIdent:', strIdent, '=>', boolMark);
+
+    boolMarkcache[strIdent] = boolMark;
+
+    for (var objVideo of document.querySelectorAll('a.ytd-thumbnail[href^="/watch?v=' + strIdent + '"], a.ytd-thumbnail[href^="/shorts/' + strIdent + '"]')) {
+        markStyle(objVideo, boolMark);
+    }
+};
+
+var markStyle = function(objVideo, boolMark) {
     if ((boolMark === true) && (objVideo.classList.contains('youwatch-mark') === false)) {
         objVideo.classList.add('youwatch-mark');
 
@@ -73,13 +87,7 @@ chrome.runtime.onMessage.addListener(function(objData, sender, sendResponse) {
     }
 
     if (objData.strMessage === 'youtubeMark') {
-        console.debug('youtubeMark:', objData.strIdent);
-
-        boolMarkcache[objData.strIdent] = true;
-
-        for (var objVideo of document.querySelectorAll('a.ytd-thumbnail[href^="/watch?v=' + objData.strIdent + '"], a.ytd-thumbnail[href^="/shorts/' + objData.strIdent + '"]')) {
-            mark(objVideo, true);
-        }
+        mark(objData.strIdent, true);
     }
 
     // synchronous response to prevent "The message port closed before a response was received."


### PR DESCRIPTION
Commits:
1. Watchmarker balks on the recommended videos in the YT watch page. `refresh` now handles such video recommendations
2. Fix minor switch-like if/else chain issue.
3. `chrome.runtime.onMessage` listeners are now explicitly synchronous. This prevents "The message port closed before a response was received." in `chrome.runtime.lastError` that causes `funcSendmessage` to effectively always retry 100 times.
4. Improve regex usage, removing unnecessary groups
5. Replace unreliable thumbnail request-based lookup with explicit lookups from content script via new `youtubeLookup` message. It was unreliable due to image caching sometimes preventing thumbnail requests. This mostly applies to shorts, since watched non-shorts should be handled by `youtubeEnsure`.
6. Revision of commit 5: Make `youtubeLookup` reply via callback rather than sending `youtubeMark`. Also now makes the background ``chrome.runtime.onMessage` listener` asynchonous while still avoiding the error that was fixed in commit 3.

You seem to be using some sort of transpiling framework so this may not be directly merge-able, but it shouldn't be difficult to replicate these changes in your pre-transpiled source.