### PR TITLE
feat: add dark mode support

### DIFF
--- a/content/index.js
+++ b/content/index.js
@@ -57,7 +57,7 @@ jQuery(window.document).ready(function() {
                 ;
 
             }
-            
+
             jQuery('#idLoading_Close')
                 .removeClass('disabled')
             ;
@@ -122,7 +122,7 @@ jQuery(window.document).ready(function() {
                 ;
 
             }
-            
+
             jQuery('#idLoading_Close')
                 .removeClass('disabled')
             ;
@@ -588,7 +588,7 @@ jQuery(window.document).ready(function() {
                     'intSkip': jQuery('#idSearch_Lookup').data('intSkip'),
                     'intLength': 10
                 }
-            }); 
+            });
         })
         .each(function() {
             jQuery(this).triggerHandler('click');
@@ -796,7 +796,7 @@ jQuery(window.document).ready(function() {
                 ;
 
             }
-            
+
             jQuery('#idLoading_Close')
                 .removeClass('disabled')
             ;
@@ -815,3 +815,24 @@ jQuery(window.document).ready(function() {
         })
     ;
 });
+
+// adapted from https://getbootstrap.com/docs/5.3/customize/color-modes/#javascript
+window.addEventListener('DOMContentLoaded', () => {
+    const getPreferredTheme = () => {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+
+    const setTheme = function (theme) {
+        if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            document.documentElement.setAttribute('data-bs-theme', 'dark')
+        } else {
+            document.documentElement.setAttribute('data-bs-theme', theme)
+        }
+    }
+
+    setTheme(getPreferredTheme())
+
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+        setTheme(getPreferredTheme())
+    })
+})


### PR DESCRIPTION
I make a followup to PR #87.

It appears that Bootstrap v5.3 (currently in alpha) has added support for dark mode.
https://getbootstrap.com/docs/5.3/customize/color-modes/

To make the changes work, I think we should update the bundle Bootstrap to `5.3.0` from `5.1.3`.